### PR TITLE
Feat: Fix Curseforge restricted mods giving wrong url (#64)

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/ModsSearchFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/ModsSearchFragment.java
@@ -238,8 +238,9 @@ public class ModsSearchFragment extends Fragment implements ModItemAdapter.Searc
                     && (modDetail.isRestricted || url == null || url.isEmpty());
 
             if (isCfRestricted) {
-                // Show dialog directing user to download from CurseForge website
-                String cfUrl = "https://www.curseforge.com/minecraft/mc-mods/" + modDetail.id;
+                String cfUrl = (modDetail.websiteUrl != null && !modDetail.websiteUrl.isEmpty())
+                        ? modDetail.websiteUrl
+                        : "https://www.curseforge.com/minecraft/mc-mods/" + modDetail.id;
                 Context dialogCtx = mActivityContext != null ? mActivityContext : context;
                 mMainHandler.post(() ->
                     new AlertDialog.Builder(dialogCtx)

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/modpacks/api/CurseforgeApi.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/modpacks/api/CurseforgeApi.java
@@ -79,6 +79,12 @@ public class CurseforgeApi implements ModpackApi{
             // Gson automatically casts null to false, which leans to issues
             // So, only check the distribution flag if it is non-null
             boolean restricted = !allowModDistribution.isJsonNull() && !allowModDistribution.getAsBoolean();
+            // For modpacks, skip restricted entries entirely (same as before)
+            // For individual mods, keep them so we can show the CF website dialog
+            if (restricted && searchFilters.isModpack) {
+                Log.i("CurseforgeApi", "Skipping modpack "+dataElement.get("name").getAsString() + " because curseforge sucks");
+                continue;
+            }
             JsonObject logo = dataElement.getAsJsonObject("logo");
             String thumbnailUrl = (logo != null && logo.has("thumbnailUrl") && !logo.get("thumbnailUrl").isJsonNull())
                     ? logo.get("thumbnailUrl").getAsString() : "";
@@ -89,6 +95,16 @@ public class CurseforgeApi implements ModpackApi{
                     dataElement.get("summary").getAsString(),
                     thumbnailUrl);
             modItem.isRestricted = restricted;
+            // Capture the mod page URL from CF API for use in restriction dialog
+            JsonObject links = dataElement.getAsJsonObject("links");
+            if (links != null && links.has("websiteUrl") && !links.get("websiteUrl").isJsonNull()) {
+                modItem.websiteUrl = links.get("websiteUrl").getAsString();
+            } else {
+                // Fallback using slug if available, otherwise numeric id
+                String slug = dataElement.has("slug") && !dataElement.get("slug").isJsonNull()
+                        ? dataElement.get("slug").getAsString() : modItem.id;
+                modItem.websiteUrl = "https://www.curseforge.com/minecraft/mc-mods/" + slug;
+            }
             modItemList.add(modItem);
         }
         if(curseforgeSearchResult == null) curseforgeSearchResult = new CurseforgeSearchResult();

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/modpacks/models/ModDetail.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/modpacks/models/ModDetail.java
@@ -24,6 +24,8 @@ public class ModDetail extends ModItem {
     public ModDetail(ModItem item, String[] versionNames, String[] mcVersionNames, String[] versionUrls, String[] hashes,
                      String[][] depIds, String[][] depTypes) {
         super(item.apiSource, item.isModpack, item.id, item.title, item.description, item.imageUrl);
+        this.isRestricted = item.isRestricted;
+        this.websiteUrl = item.websiteUrl;
         this.versionNames = versionNames;
         this.mcVersionNames = mcVersionNames;
         this.versionUrls = versionUrls;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/modpacks/models/ModItem.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/modpacks/models/ModItem.java
@@ -10,6 +10,8 @@ public class ModItem extends ModSource {
     public String imageUrl;
     /** True if the mod author blocked third-party distribution (CF allowModDistribution=false) */
     public boolean isRestricted;
+    /** Direct website URL for the mod page (used for CF restricted mods) */
+    public String websiteUrl;
 
     public ModItem(int apiSource, boolean isModpack, String id, String title, String description, String imageUrl) {
         this.apiSource = apiSource;


### PR DESCRIPTION
* fix: use CF websiteUrl for restricted mod dialog instead of broken numeric ID URL

* fix: For modpacks, skip restricted entries entirely

* fix: pass websiteUrl through ModDetail constructor to fix CF restricted mod URL