### PR TITLE
fix(sdl,ui): restore modpack filter button in landscape; fix SDL keyboard not appearing on some devices

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/keyboard/TouchCharInput.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/keyboard/TouchCharInput.java
@@ -65,7 +65,15 @@ public class TouchCharInput extends androidx.appcompat.widget.AppCompatEditText 
      * Toggle on and off the soft keyboard, depending of the state
      */
     public void switchKeyboardState(){
-        if(hasFocus()){
+        // When SDL owns the keyboard, enable() focuses SDLActivity's own dummy
+        // edit view, never `this` — so hasFocus() below would always read false
+        // and this method would always fall into enable(), unable to ever detect
+        // "already shown" and toggle it off. That made the on-screen keyboard
+        // button need several taps in-game before the IME actually appeared.
+        boolean isShown = SDLActivity.isUsingSDLTextEdit()
+                ? SDLActivity.isSDLEditKeyboardShown()
+                : hasFocus();
+        if(isShown){
             clear();
             disable();
         }else{

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/keyboard/TouchCharInput.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/keyboard/TouchCharInput.java
@@ -104,13 +104,22 @@ public class TouchCharInput extends androidx.appcompat.widget.AppCompatEditText 
             SDLActivity.enableSDLEditKeyboard();
             return;
         }
-        // Allow, regardless of whether or not a hardware keyboard is declared
-        InputMethodManager imm = (InputMethodManager) getContext().getSystemService(INPUT_METHOD_SERVICE);
-        imm.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT);
+        // Allow, regardless of whether or not a hardware keyboard is declared.
+        // setEnabled/setFocusable/setVisibility/requestFocus MUST run before
+        // showSoftInput() — this view is still disabled and GONE from the last
+        // disable() call at this point, so calling showSoftInput() first (as
+        // before) targeted a view the IME couldn't actually attach to and
+        // silently did nothing most of the time. Becoming VISIBLE also needs an
+        // actual layout pass before the view's bounds are valid for the IME to
+        // attach reliably, so showSoftInput() itself is deferred via post().
         setEnabled(true);
         setFocusable(true);
         setVisibility(VISIBLE);
         requestFocus();
+        post(() -> {
+            InputMethodManager imm = (InputMethodManager) getContext().getSystemService(INPUT_METHOD_SERVICE);
+            imm.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT);
+        });
     }
 
     /** Lose ability to exist, take focus and have some text being input */

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/SearchModFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/SearchModFragment.java
@@ -86,6 +86,13 @@ public class SearchModFragment extends Fragment implements ModItemAdapter.Search
         mRecyclerview = view.findViewById(R.id.search_mod_list);
         mStatusTextView = view.findViewById(R.id.search_mod_status_text);
         mFilterButton = view.findViewById(R.id.search_mod_filter);
+        // layout-land/fragment_mod_search.xml sets this button's visibility to
+        // GONE by default — that's meant for ModsSearchFragment (mod/resource/
+        // /shader search), which is hosted inside ContentPickerFragment's two-pane
+        // picker and has its own left-pane filter button in landscape instead.
+        // This fragment (the standalone modpack search/installer) has no such
+        // host or alternate filter entry point, so force it back on here.
+        mFilterButton.setVisibility(View.VISIBLE);
 
         mDefaultTextColor = mStatusTextView.getTextColors();
 

--- a/app_pojavlauncher/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/app_pojavlauncher/src/main/java/org/libsdl/app/SDLActivity.java
@@ -388,6 +388,17 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     public static void enableSDLEditKeyboard(){
         if (mTextEdit == null) return;
 
+        // disableSDLEditKeyboard() (or the initial state) can leave mTextEdit at
+        // 0x0 size. A 0x0 view can't reliably take focus or have the IME attach to
+        // it on some OEM keyboards — same "minimum size of 1 pixel, so it takes
+        // focus" requirement as the CommandHandler#COMMAND_TEXTEDIT_SHOW path below.
+        // Skipping this made the keyboard slow to appear, or never appear, on
+        // devices whose IME is strict about laid-out view bounds before showing.
+        FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) mTextEdit.getLayoutParams();
+        if (params == null || params.width <= 0 || params.height <= 0) {
+            mTextEdit.setLayoutParams(new FrameLayout.LayoutParams(1, 1));
+        }
+
         mTextEdit.setInputType(TYPE_CLASS_TEXT | TYPE_TEXT_VARIATION_NORMAL);
 
         mTextEdit.setVisibility(View.VISIBLE);

--- a/app_pojavlauncher/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/app_pojavlauncher/src/main/java/org/libsdl/app/SDLActivity.java
@@ -392,28 +392,36 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     public static void enableSDLEditKeyboard(){
         if (mTextEdit == null) return;
 
-        // disableSDLEditKeyboard() (or the initial state) can leave mTextEdit at
-        // 0x0 size. A 0x0 view can't reliably take focus or have the IME attach to
-        // it on some OEM keyboards — same "minimum size of 1 pixel, so it takes
-        // focus" requirement as the CommandHandler#COMMAND_TEXTEDIT_SHOW path below.
-        // Skipping this made the keyboard slow to appear, or never appear, on
-        // devices whose IME is strict about laid-out view bounds before showing.
-        FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) mTextEdit.getLayoutParams();
-        if (params == null || params.width <= 0 || params.height <= 0) {
-            mTextEdit.setLayoutParams(new FrameLayout.LayoutParams(1, 1));
-        }
+        // Deferred via commandHandler.post(), same as showTextInput()/
+        // ShowTextInputTask below: running requestFocus()/showSoftInput()
+        // synchronously from inside the calling touch-event callback stack
+        // (e.g. a control button's onTouchEvent) is unreliable on some devices —
+        // the window/IME state isn't always ready for a focus request made
+        // mid-dispatch. Posting lets it run on a clean looper iteration instead.
+        commandHandler.post(() -> {
+            if (mTextEdit == null) return;
 
-        mTextEdit.setInputType(TYPE_CLASS_TEXT | TYPE_TEXT_VARIATION_NORMAL);
+            // disableSDLEditKeyboard() (or the initial state) can leave mTextEdit
+            // at 0x0 size. A 0x0 view can't reliably take focus or have the IME
+            // attach to it on some OEM keyboards — same "minimum size of 1 pixel,
+            // so it takes focus" requirement as ShowTextInputTask uses below.
+            FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) mTextEdit.getLayoutParams();
+            if (params == null || params.width <= 0 || params.height <= 0) {
+                mTextEdit.setLayoutParams(new FrameLayout.LayoutParams(1, 1));
+            }
 
-        mTextEdit.setVisibility(View.VISIBLE);
-        mTextEdit.requestFocus();
+            mTextEdit.setInputType(TYPE_CLASS_TEXT | TYPE_TEXT_VARIATION_NORMAL);
 
-        InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
-        imm.showSoftInput(mTextEdit, 0);
+            mTextEdit.setVisibility(View.VISIBLE);
+            mTextEdit.requestFocus();
 
-        if (imm.isAcceptingText()) {
-            onNativeScreenKeyboardShown();
-        }
+            InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+            imm.showSoftInput(mTextEdit, 0);
+
+            if (imm.isAcceptingText()) {
+                onNativeScreenKeyboardShown();
+            }
+        });
     }
     public static void disableSDLEditKeyboard(){
         mTextEdit.setLayoutParams(new FrameLayout.LayoutParams(0, 0));

--- a/app_pojavlauncher/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/app_pojavlauncher/src/main/java/org/libsdl/app/SDLActivity.java
@@ -385,6 +385,10 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     public static boolean isUsingSDLTextEdit(){
         return mTextEdit != null;
     }
+    /** True if the SDL-owned text edit is currently the one showing/holding the keyboard. */
+    public static boolean isSDLEditKeyboardShown(){
+        return mTextEdit != null && mTextEdit.hasFocus();
+    }
     public static void enableSDLEditKeyboard(){
         if (mTextEdit == null) return;
 

--- a/app_pojavlauncher/src/main/res/layout-land/fragment_mod_search.xml
+++ b/app_pojavlauncher/src/main/res/layout-land/fragment_mod_search.xml
@@ -28,9 +28,13 @@
 
 
         >
-        <!-- Search text: fills the full width here since the filter button now lives
-             in ContentPickerFragment's left pane (see fragment_content_picker.xml)
-             instead of next to this search box. -->
+        <!-- Search text: end-constrained to the filter button's start, same as the
+             portrait layout. ConstraintLayout collapses a GONE view for constraint
+             purposes, so this still expands to fill the row for ModsSearchFragment
+             (mod/resource/shader search, filter button left GONE — its filter now
+             lives in ContentPickerFragment's left pane instead), while correctly
+             leaving room for the button when SearchModFragment (modpack search)
+             forces it back to VISIBLE in code. -->
         <EditText
             android:id="@+id/search_mod_edittext"
             android:layout_width="0dp"
@@ -45,7 +49,7 @@
             android:paddingHorizontal="@dimen/padding_heavy"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/search_mod_filter"
             />
 
         <!-- Kept in the tree (same id, GONE) so ModsSearchFragment.java's findViewById


### PR DESCRIPTION
SearchModFragment/fragment_mod_search.xml (layout-land): the shared
  landscape layout hid the filter button unconditionally to remove a
  duplicate in ModsSearchFragment (mod/res/shader search, which now
  uses ContentPickerFragment's left-pane filter). This also hid it in
  SearchModFragment (standalone modpack installer), which has no such
  alternate entry point. Force it visible there and restore the
  search box's adaptive end-constraint to the filter button.

- SDLActivity: enableSDLEditKeyboard() showed/focused mTextEdit
  without restoring its layout size, which disableSDLEditKeyboard()
  collapses to 0x0. A 0x0 view can't reliably take focus or have the
  IME attach on some OEM keyboards, causing the on-screen keyboard to
  be slow or fail to appear. Restore a minimum 1x1 size before
  requesting focus/showSoftInput, matching the existing
  "minimum size of 1 pixel, so it takes focus" requirement used by
  COMMAND_TEXTEDIT_SHOW.
